### PR TITLE
In the case that we are given a empty string or whitespace, we should…

### DIFF
--- a/OmopTransformer/ConceptLookup.cs
+++ b/OmopTransformer/ConceptLookup.cs
@@ -53,7 +53,7 @@ internal abstract class ConceptLookup
             }
         }
 
-        if (code == null)
+        if (string.IsNullOrWhiteSpace(code))
         {
             return unknownConceptId;
         }


### PR DESCRIPTION
… treat it the same as null.